### PR TITLE
pluracoind: add docker definition file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && \
+    apt-get --no-install-recommends --yes install \
+         git \
+         automake \
+         build-essential \
+         libtool \
+         cmake \
+         autotools-dev \
+         autoconf \
+         pkg-config \
+         libssl-dev \ 
+         libboost-all-dev \
+         libevent-dev \
+         bsdmainutils \
+         vim \
+         software-properties-common
+
+RUN add-apt-repository ppa:bitcoin/bitcoin && \
+    apt-get update && \
+    apt-get --no-install-recommends --yes install \
+          libdb4.8-dev \
+          libdb4.8++-dev \
+          libminiupnpc-dev 
+
+WORKDIR /pluracoin
+
+ENV PLURACOIN_VERSION 1.5.0 
+
+RUN git clone https://github.com/pluracoin/PluraCoin.git . && \
+    git checkout $PLURACOIN_VERSION && \
+    make
+
+VOLUME ["/root/.pluracoin"]
+
+EXPOSE 19200
+
+ENTRYPOINT ["/pluracoin/build/release/src/./pluracoind"]


### PR DESCRIPTION
Builds the pluracoin core as a docker image. Useful for
easy deployment for cli wallets and full nodes. Docker is supported
on Mac OSX, Windows and Linux.

To test simply install Docker: https://docs.docker.com/install/

From this repo: docker build -t pluracoind .

To run: docker run -it pluracoind [daemon args]

To run as headless daemon: docker run -dit pluracoind [daemon args]

Signed-off-by: Tyler Baker <tyler@opensourcefoundries.com>